### PR TITLE
ignoring node_modules folder at all levels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules
+node_modules
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
When running locally with `yarn workspace web start`, the folder `web/node_modules` is created. It is not currently covered by the `.gitignore` file — this PR changes that.